### PR TITLE
Fixed behavior of calibrate_spectrum if a threshold is set as an argument

### DIFF
--- a/flexcalc/analyze.py
+++ b/flexcalc/analyze.py
@@ -446,13 +446,11 @@ def calibrate_spectrum(projections, volume, geometry, compound = 'Al', density =
     #import random
     
     # Find the shape of the object:                                                    
-    if threshold:
+    if threshold is not None:
         t = binary_threshold(volume, mode = 'constant', threshold = threshold)
-        
-        segmentation = numpy.float32()
     else:
         t = binary_threshold(volume, mode = 'otsu')
-        segmentation = numpy.float32(volume > t)
+    segmentation = numpy.float32(volume > t)
         
     display.slice(segmentation, dim=0,title = 'Segmentation')        
         


### PR DESCRIPTION
When calling calibrate_spectrum with a threshold as argument the code used to crash because the code that was intended to convert a boolean segmentation mask to float32 was not correct. This is fixed in this pull request.