### PR TITLE
Updated conda channels in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ We recommend that the user installs [conda package manager](https://docs.anacond
 
 ### Installing with conda
 
-`conda install flexcalc -c cicwi -c astra-toolbox -c nvidia`
+`conda install flexcalc -c cicwi -c astra-toolbox -c nvidia -c SimpleITK`
 
 ### Installing with pip
 


### PR DESCRIPTION
Current conda install leads to an error
```
Could not solve for environment specs
The following packages are incompatible
└─ flexcalc is not installable because there are no viable options
   ├─ flexcalc 0.1.0 would require
   │  └─ numpy-stl, which does not exist (perhaps a missing channel);
   └─ flexcalc 1.0.0 would require
      └─ simpleitk, which does not exist (perhaps a missing channel).
```
SimpleITK is added to the list of channels to address the issue
